### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Harassment includes offensive comments related to gender, sexual orientation, di
 
 Participants asked to stop any harassing behavior are expected to comply immediately.
 
-If you are being harassed, notice that someone else is being harassed, or have any other concerns, please notify an administrator immediately, or email <atldevs@forty9ten.com>.
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please notify an administrator immediately, or email <mail@chrishoog.com>.
 
 [This code of conduct is adapted from [tech404 Code of Conduct] (https://github.com/tech404/CoC) which was adapted from [Conference Code of Conduct](http://confcodeofconduct.com) under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/deed.en_US), with additional content adapted from the [Gopher Academy Slack Code of Conduct](https://docs.google.com/document/d/1YO_xIZPhD1OsquKdCuAq-fFECs8b37wfhVRfnx3DjzM/edit)]
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# tech404 Code of Conduct
+# Oakland TechEquity Code of Conduct
 
-All participants in the tech404 chat are expected to follow the code of conduct. Administrators will enforce this code.
+All participants in the Oakland TechEquity chat are expected to follow the code of conduct. Administrators will enforce this code.
 
 # The Quick Version
 
-tech404 is dedicated to providing a harassment-free experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of participants in any form. Sexual language and imagery is not appropriate for any chat topic. Participants violating these rules will be expelled from the group at the sole discretion of the group administrators.
+Oakland TechEquity is dedicated to providing a harassment-free experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of participants in any form. Sexual language and imagery is not appropriate for any chat topic. Participants violating these rules will be expelled from the group at the sole discretion of the group administrators.
 
 # The Less Quick Version
 
@@ -14,21 +14,16 @@ Participants asked to stop any harassing behavior are expected to comply immedia
 
 If you are being harassed, notice that someone else is being harassed, or have any other concerns, please notify an administrator immediately, or email <atldevs@forty9ten.com>.
 
-[This code of conduct is adapted from [Conference Code of Conduct](http://confcodeofconduct.com) under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/deed.en_US), additional content adapted from the [Gopher Academy Slack Code of Conduct](https://docs.google.com/document/d/1YO_xIZPhD1OsquKdCuAq-fFECs8b37wfhVRfnx3DjzM/edit)]
+[This code of conduct is adapted from [tech404 Code of Conduct] (https://github.com/tech404/CoC) which was adapted from [Conference Code of Conduct](http://confcodeofconduct.com) under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/deed.en_US), with additional content adapted from the [Gopher Academy Slack Code of Conduct](https://docs.google.com/document/d/1YO_xIZPhD1OsquKdCuAq-fFECs8b37wfhVRfnx3DjzM/edit)]
 
 # Admins
 
 If you have any issues or need help, please feel free to reach out to anyone on this list:
 
-* Aaron Feng (<aaron@forty9ten.com>)
-* Andy Lindeman
-* J Cornelius
-* John Dyer
-* Kylie Stradley (<ky@kyfast.net>)
-* Michael Langford
-* Pamela O. Vickers (<pwnela@gmail.com>)
-* Patrick Van Stee
-* Randall McPherson
+* Chris Hoogewerff
+* Darrell Jones
+* Jesse Pollak
+* Brennen Byrne
 
 ## Role of Admins
 


### PR DESCRIPTION
Adapted Tech404's code of conduct for Oakland TechEquity, and included the list of admins.
